### PR TITLE
Fixes to allow running as an NPM module inside a docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM node:5.2.0
 MAINTAINER SaaS Team "<saas@docker.com>"
 
 # run npm install, which collects stuff defined in package.json
-COPY selenium_test_runner.tar.gz /test/
 COPY package.json /test/
 WORKDIR /test
 RUN npm install

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ And your Node.js installation
 ```
 {
   "dependencies": {
-      "selenium_test_runner": "git+ssh://git@github.com:davidwilliamson/selenium-test-framework.git"
+    "selenium_test_runner": "git+https://github.com/davidwilliamson/selenium-test-framework.git"
   },
   "scripts": {
     "selenium": "./node_modules/selenium_test_runner/scripts/start-tests.sh",
@@ -86,6 +86,7 @@ And your Node.js installation
 }
 ```
 Now install this repository as an NPM package
+
 `npm install`
 
 # Creating tests

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ test_framework:
     environment:
         BROWSER:
         ENV:
-        #TESTS_DIR:
-        #PAGEOBJECTS_DIR:
         RESULTS_DIR:
     volumes:
         - "${TESTS_DIR}:/test/test"


### PR DESCRIPTION
* Remove reference to tarsal from Dockerfile (we now get source via github)
* Remove debug messages from start-tests.sh
* Update README to show correct github syntax